### PR TITLE
fix pagination page calculations

### DIFF
--- a/src/components/paginate.tsx
+++ b/src/components/paginate.tsx
@@ -13,9 +13,11 @@ interface PaginateProps {
   total: number
 }
 
-const pages = Array.from({ length: 5 }, (_, i) => ({ value: i + 1 }))
 export function Paginate({ from, to, total }: PaginateProps) {
-  const currentPage = from === 1 ? 1 : Number(from.toString()[0]) + 1
+  const itemsPerPage = to - from + 1
+  const currentPage = Math.floor((from - 1) / itemsPerPage) + 1
+  const totalPages = Math.ceil(total / itemsPerPage)
+  const pages = Array.from({ length: Math.min(totalPages, 5) }, (_, i) => ({ value: i + 1 }))
   return (
     <Pagination className="flex-col items-center gap-4 md:flex-row md:justify-between">
       <p className="text-muted-fg text-sm/6 *:[strong]:font-medium *:[strong]:text-fg">
@@ -29,7 +31,7 @@ export function Paginate({ from, to, total }: PaginateProps) {
           <PaginationItem segment="label">1</PaginationItem>
           <PaginationItem segment="separator" />
           <PaginationItem className="text-muted-fg" segment="label">
-            {total}
+            {totalPages}
           </PaginationItem>
         </PaginationSection>
 
@@ -45,8 +47,8 @@ export function Paginate({ from, to, total }: PaginateProps) {
             </PaginationItem>
           ))}
           <PaginationItem segment="ellipsis" />
-          <PaginationItem id={String(total)} href="#">
-            {total - to}
+          <PaginationItem id={String(totalPages)} href="#">
+            {totalPages}
           </PaginationItem>
         </PaginationSection>
 


### PR DESCRIPTION
## Summary
- correct current page and total page computation for Paginate component
- display last page number accurately

## Testing
- `bun run format`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68ab2fab796c83208adee3bf22ead260